### PR TITLE
Changing default configs and capistrano deploy

### DIFF
--- a/.travis-ci.yml
+++ b/.travis-ci.yml
@@ -1,0 +1,38 @@
+sudo: required
+dist: trusty
+
+services:
+  - postgres
+
+language: ruby
+
+branches:
+  only:
+    - master
+
+before_script:
+  - bundle exec rake db:create db:schema:load
+  - bundle exec rake decidim:generate_external_test_app
+
+env:
+  - RAILS_ENV=test
+
+cache:
+  bundler: true
+  directories:
+    - $TRAVIS_BUILD_DIR/.yarn-cache
+    - $TRAVIS_BUILD_DIR/node_modules
+    - $BUNDLE_PATH
+    - vendor/bundle
+script:
+  - bundle exec rake
+
+rvm:
+  - 2.4.0
+
+notifications:
+  email: false
+
+addons:
+  postgresql: "9.4"
+

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -7,5 +7,5 @@ set :deploy_to, "/var/www/dcm.alabs.org"
 set :passenger_restart_with_touch, true
 set :rbenv_type, :user
 
-#append :linked_files, "config/database.yml", "config/secrets.yml"
+append :linked_files, "config/application.yml"
 append :linked_dirs, "log", "tmp/pids", "tmp/cache", "tmp/sockets", "public/system"

--- a/config/initializers/decidim.rb
+++ b/config/initializers/decidim.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 Decidim.configure do |config|
-  config.application_name = "My Application Name"
-  config.mailer_sender = "change-me@domain.org"
+  config.application_name = "DCM aLabs"
+  config.mailer_sender = "decidim@alabs.org"
   config.authorization_handlers = ["ExampleAuthorizationHandler"]
 
   # Change these lines to set your preferred locales


### PR DESCRIPTION
This adds: 
* Travis-CI configuration 
* Fixes capistrano deploy with figaro 
* Changes default email and name for DCM/Decidim 